### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/net/diecode/killermoney/functions/MessageHandler.java
+++ b/src/net/diecode/killermoney/functions/MessageHandler.java
@@ -64,7 +64,7 @@ public class MessageHandler implements Listener {
         KMPlayer kmp = KMPlayerManager.getKMPlayer(player);
         PluginManager pm = Bukkit.getPluginManager();
 
-        if (!kmp.isEnableMessages()) {
+        if (kmp == null || !kmp.isEnableMessages()) {
             return;
         }
 


### PR DESCRIPTION
Caused by: java.lang.NullPointerException
        at net.diecode.killermoney.functions.MessageHandler.process(MessageHandler.java:67) ~[?:?]
        at net.diecode.killermoney.functions.CashTransferHandler.onLoseMoneyCashTransfer(CashTransferHandler.java:111) ~[?:?]
        at sun.reflect.GeneratedMethodAccessor478.invoke(Unknown Source) ~[?:?]
        at