### PR TITLE
Fix stacked items only issuing the amount of one item

### DIFF
--- a/src/net/diecode/killermoney/functions/MoneyHandler.java
+++ b/src/net/diecode/killermoney/functions/MoneyHandler.java
@@ -201,7 +201,7 @@ public class MoneyHandler implements Listener {
             e.setCancelled(true);
 
             BigDecimal money = new BigDecimal(Double.valueOf(ChatColor.stripColor(is.getItemMeta().getLore().get(0))
-                    .replaceAll("[^0-9.]", "")))
+                    .replaceAll("[^0-9.]", "")) * is.getAmount())
                     .setScale(DefaultConfig.getDecimalPlaces(), BigDecimal.ROUND_HALF_EVEN);
 
             EntityType entityType = EntityType.valueOf(is.getItemMeta().getLore().get(1));


### PR DESCRIPTION
When you pick up a stack of, say, 3 $10 items that were merged together, the plugin only issues the amount of money that one of those $10 items would give.  This PR should fix that.