### PR TITLE
Add api-version on plugin.yml

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,7 @@
 name: KillerMoney
 main: net.diecode.killermoney.BukkitMain
 version: 4.6.0
+api-version: "1.13"
 softdepend: [Vault, MobArena, Multiverse-Core]
 author: diecode
 website: https://www.spigotmc.org/resources/killermoney.485/


### PR DESCRIPTION
Remove warning Legacy plugin KillerMoney v4.6.0 does not specify an api-version on startup.
Close #35 